### PR TITLE
feat: collect/store resource status

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -208,10 +208,11 @@ func startControllers(opts *options.Options, stopChan <-chan struct{}) {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PushReconciler) {
 		if utilfeature.DefaultFeatureGate.Enabled(features.RawResourceStatusCollection) {
+			opts.Config.RawResourceStatusCollection = true
 			klog.Info("Enabling RawResourceStatusCollection for all the enabled federated resources")
 		}
 
-		if err := federatedtypeconfig.StartController(opts.Config, opts.FeatureGates, stopChan); err != nil {
+		if err := federatedtypeconfig.StartController(opts.Config, stopChan); err != nil {
 			klog.Fatalf("Error starting federated type config controller: %v", err)
 		}
 	}

--- a/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
@@ -207,18 +207,20 @@ func (f *FederatedTypeConfig) GetFederatedType() metav1.APIResource {
 	return apiResourceToMeta(f.Spec.FederatedType, f.GetFederatedNamespaced())
 }
 
+// TODO (hectorj2f): It should get deprecated once we move to the new status approach
+// because the type is the same than the target type.
 func (f *FederatedTypeConfig) GetStatusType() *metav1.APIResource {
 	if f.Spec.StatusType == nil {
 		return nil
 	}
+	// Return the original target type
 	metaAPIResource := apiResourceToMeta(*f.Spec.StatusType, f.Spec.StatusType.Namespaced())
 	return &metaAPIResource
 }
 
 func (f *FederatedTypeConfig) GetStatusEnabled() bool {
 	return f.Spec.StatusCollection != nil &&
-		*f.Spec.StatusCollection == StatusCollectionEnabled &&
-		f.Name == "services"
+		*f.Spec.StatusCollection == StatusCollectionEnabled
 }
 
 // TODO(font): This method should be removed from the interface i.e. remove

--- a/pkg/controller/sync/dispatch/managed.go
+++ b/pkg/controller/sync/dispatch/managed.go
@@ -30,6 +30,7 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog"
 
 	"sigs.k8s.io/kubefed/pkg/client/generic"
 	"sigs.k8s.io/kubefed/pkg/controller/sync/status"
@@ -60,10 +61,10 @@ type ManagedDispatcher interface {
 	Create(clusterName string)
 	Update(clusterName string, clusterObj *unstructured.Unstructured)
 	VersionMap() map[string]string
-	CollectedStatus() status.CollectedPropagationStatus
+	CollectedStatus() (status.CollectedPropagationStatus, status.CollectedResourceStatus)
 
 	RecordClusterError(propStatus status.PropagationStatus, clusterName string, err error)
-	RecordStatus(clusterName string, propStatus status.PropagationStatus)
+	RecordStatus(clusterName string, propStatus status.PropagationStatus, resourceStatus interface{})
 }
 
 type managedDispatcherImpl struct {
@@ -74,19 +75,24 @@ type managedDispatcherImpl struct {
 	fedResource           FederatedResourceForDispatch
 	versionMap            map[string]string
 	statusMap             status.PropagationStatusMap
+	resourceStatusMap     map[string]interface{}
 	skipAdoptingResources bool
 
 	// Track when resource updates are performed to allow indicating
 	// when a change was last propagated to member clusters.
 	resourcesUpdated bool
+
+	rawResourceStatusCollection bool
 }
 
-func NewManagedDispatcher(clientAccessor clientAccessorFunc, fedResource FederatedResourceForDispatch, skipAdoptingResources bool) ManagedDispatcher {
+func NewManagedDispatcher(clientAccessor clientAccessorFunc, fedResource FederatedResourceForDispatch, skipAdoptingResources, rawResourceStatusCollection bool) ManagedDispatcher {
 	d := &managedDispatcherImpl{
-		fedResource:           fedResource,
-		versionMap:            make(map[string]string),
-		statusMap:             make(status.PropagationStatusMap),
-		skipAdoptingResources: skipAdoptingResources,
+		fedResource:                 fedResource,
+		versionMap:                  make(map[string]string),
+		statusMap:                   make(status.PropagationStatusMap),
+		resourceStatusMap:           make(map[string]interface{}),
+		skipAdoptingResources:       skipAdoptingResources,
+		rawResourceStatusCollection: rawResourceStatusCollection,
 	}
 	d.dispatcher = newOperationDispatcher(clientAccessor, d)
 	d.unmanagedDispatcher = newUnmanagedDispatcher(d.dispatcher, d, fedResource.TargetGVK(), fedResource.TargetName())
@@ -132,7 +138,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 	// when a timeout occurs it won't be possible to determine which
 	// operation timed out.  The timeout status will be cleared by
 	// Wait() if a timeout does not occur.
-	d.RecordStatus(clusterName, status.CreationTimedOut)
+	d.RecordStatus(clusterName, status.CreationTimedOut, nil)
 	start := time.Now()
 	d.dispatcher.incrementOperationsInitiated()
 	const op = "create"
@@ -153,6 +159,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 		if err == nil {
 			version := util.ObjectVersion(obj)
 			d.recordVersion(clusterName, version)
+			d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
 			metrics.DispatchOperationDurationFromStart("create", start)
 			return util.StatusAllOK
 		}
@@ -172,6 +179,8 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 			return d.recordOperationError(status.RetrievalFailed, clusterName, op, wrappedErr)
 		}
 
+		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+
 		if d.skipAdoptingResources && !d.fedResource.IsNamespaceInHostCluster(obj) {
 			_ = d.recordOperationError(status.AlreadyExists, clusterName, op, errors.Errorf("Resource pre-exist in cluster"))
 			return util.StatusAllOK
@@ -185,7 +194,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 }
 
 func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructured.Unstructured) {
-	d.RecordStatus(clusterName, status.UpdateTimedOut)
+	d.RecordStatus(clusterName, status.UpdateTimedOut, clusterObj.Object[util.StatusField])
 
 	d.dispatcher.incrementOperationsInitiated()
 	const op = "update"
@@ -217,6 +226,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		}
 		if !util.ObjectNeedsUpdate(obj, clusterObj, version) {
 			// Resource is current
+			d.RecordStatus(clusterName, status.ClusterPropagationOK, clusterObj.Object[util.StatusField])
 			return util.StatusAllOK
 		}
 
@@ -227,6 +237,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		if err != nil {
 			return d.recordOperationError(status.UpdateFailed, clusterName, op, err)
 		}
+		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
 		d.setResourcesUpdated()
 		version = util.ObjectVersion(obj)
 		d.recordVersion(clusterName, version)
@@ -235,31 +246,36 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 }
 
 func (d *managedDispatcherImpl) Delete(clusterName string) {
-	d.RecordStatus(clusterName, status.DeletionTimedOut)
+	d.RecordStatus(clusterName, status.DeletionTimedOut, nil)
 
 	d.unmanagedDispatcher.Delete(clusterName)
 }
 
 func (d *managedDispatcherImpl) RemoveManagedLabel(clusterName string, clusterObj *unstructured.Unstructured) {
-	d.RecordStatus(clusterName, status.LabelRemovalTimedOut)
+	d.RecordStatus(clusterName, status.LabelRemovalTimedOut, clusterObj.Object[util.StatusField])
 
 	d.unmanagedDispatcher.RemoveManagedLabel(clusterName, clusterObj)
 }
 
 func (d *managedDispatcherImpl) RecordClusterError(propStatus status.PropagationStatus, clusterName string, err error) {
 	d.fedResource.RecordError(string(propStatus), err)
-	d.RecordStatus(clusterName, propStatus)
+	d.RecordStatus(clusterName, propStatus, "UnknownClusterError")
 }
 
-func (d *managedDispatcherImpl) RecordStatus(clusterName string, propStatus status.PropagationStatus) {
+func (d *managedDispatcherImpl) RecordStatus(clusterName string, propStatus status.PropagationStatus, resourceStatus interface{}) {
 	d.Lock()
 	defer d.Unlock()
 	d.statusMap[clusterName] = propStatus
+
+	if d.rawResourceStatusCollection && resourceStatus != nil {
+		klog.Infof("Recording resource status %v", resourceStatus)
+		d.resourceStatusMap[clusterName] = resourceStatus
+	}
 }
 
 func (d *managedDispatcherImpl) recordOperationError(propStatus status.PropagationStatus, clusterName, operation string, err error) util.ReconciliationStatus {
 	d.recordError(clusterName, operation, err)
-	d.RecordStatus(clusterName, propStatus)
+	d.RecordStatus(clusterName, propStatus, "UnknownOperationError")
 	return util.StatusError
 }
 
@@ -299,15 +315,23 @@ func (d *managedDispatcherImpl) setResourcesUpdated() {
 	d.resourcesUpdated = true
 }
 
-func (d *managedDispatcherImpl) CollectedStatus() status.CollectedPropagationStatus {
+func (d *managedDispatcherImpl) CollectedStatus() (status.CollectedPropagationStatus, status.CollectedResourceStatus) {
 	d.RLock()
 	defer d.RUnlock()
 	statusMap := make(status.PropagationStatusMap)
+	resourceStatusMap := make(map[string]interface{})
 	for key, value := range d.statusMap {
 		statusMap[key] = value
 	}
-	return status.CollectedPropagationStatus{
-		StatusMap:        statusMap,
-		ResourcesUpdated: d.resourcesUpdated,
+
+	for key, value := range d.resourceStatusMap {
+		resourceStatusMap[key] = value
 	}
+	return status.CollectedPropagationStatus{
+			StatusMap:        statusMap,
+			ResourcesUpdated: d.resourcesUpdated,
+		}, status.CollectedResourceStatus{
+			StatusMap:        resourceStatusMap,
+			ResourcesUpdated: d.resourcesUpdated,
+		}
 }

--- a/pkg/controller/sync/dispatch/managed.go
+++ b/pkg/controller/sync/dispatch/managed.go
@@ -159,7 +159,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 		if err == nil {
 			version := util.ObjectVersion(obj)
 			d.recordVersion(clusterName, version)
-			d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+			d.RecordStatus(clusterName, status.CreationTimedOut, obj.Object[util.StatusField])
 			metrics.DispatchOperationDurationFromStart("create", start)
 			return util.StatusAllOK
 		}
@@ -179,7 +179,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 			return d.recordOperationError(status.RetrievalFailed, clusterName, op, wrappedErr)
 		}
 
-		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+		d.RecordStatus(clusterName, status.CreationTimedOut, obj.Object[util.StatusField])
 
 		if d.skipAdoptingResources && !d.fedResource.IsNamespaceInHostCluster(obj) {
 			_ = d.recordOperationError(status.AlreadyExists, clusterName, op, errors.Errorf("Resource pre-exist in cluster"))
@@ -226,7 +226,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		}
 		if !util.ObjectNeedsUpdate(obj, clusterObj, version) {
 			// Resource is current
-			d.RecordStatus(clusterName, status.ClusterPropagationOK, clusterObj.Object[util.StatusField])
+			d.RecordStatus(clusterName, status.UpdateTimedOut, clusterObj.Object[util.StatusField])
 			return util.StatusAllOK
 		}
 
@@ -237,7 +237,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		if err != nil {
 			return d.recordOperationError(status.UpdateFailed, clusterName, op, err)
 		}
-		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+		d.RecordStatus(clusterName, status.UpdateTimedOut, obj.Object[util.StatusField])
 		d.setResourcesUpdated()
 		version = util.ObjectVersion(obj)
 		d.recordVersion(clusterName, version)

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -65,7 +65,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			propStatus := &GenericFederatedStatus{
+			fedStatus := &GenericFederatedStatus{
 				Clusters: []GenericClusterStatus{
 					{
 						Name: "cluster1",
@@ -86,7 +86,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				StatusMap:        tc.resourceStatusMap,
 				ResourcesUpdated: tc.resourcesUpdated,
 			}
-			changed := propStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus)
+			changed := fedStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus, true)
 			if tc.expectedChanged != changed {
 				t.Fatalf("Expected changed to be %v, got %v", tc.expectedChanged, changed)
 			}

--- a/pkg/controller/util/controllerconfig.go
+++ b/pkg/controller/util/controllerconfig.go
@@ -68,11 +68,12 @@ type ClusterHealthCheckConfig struct {
 // controllers.
 type ControllerConfig struct {
 	KubeFedNamespaces
-	KubeConfig              *restclient.Config
-	ClusterAvailableDelay   time.Duration
-	ClusterUnavailableDelay time.Duration
-	MinimizeLatency         bool
-	SkipAdoptingResources   bool
+	KubeConfig                  *restclient.Config
+	ClusterAvailableDelay       time.Duration
+	ClusterUnavailableDelay     time.Duration
+	MinimizeLatency             bool
+	SkipAdoptingResources       bool
+	RawResourceStatusCollection bool
 }
 
 func (c *ControllerConfig) LimitedScope() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add the logic to collect/store the status of the federated cluster objects and append it to the federated resource status.
To use this feature, you need to enable the new feature gate and enable the statusCollection of the desired federated type config objects. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

TODO: Add more tests
