### PR TITLE
feat: tests for kubefed resource status collection

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,8 @@ types enabled by default:
 1. a label update is reflected in the objects stored in the target
    clusters.
 1. a placement update for the object is reflected in the target clusters.
+1. optionally if `RawResourceStatusCollection` feature is enabled and the env var `E2E_TEST_REMOTE_STATUS` is set, tests check the value
+of the `remoteStatus` field of federated resources.
 1. deleted resources are removed from the target clusters.
 
 The read operation is implicit.

--- a/pkg/controller/sync/dispatch/managed.go
+++ b/pkg/controller/sync/dispatch/managed.go
@@ -159,7 +159,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 		if err == nil {
 			version := util.ObjectVersion(obj)
 			d.recordVersion(clusterName, version)
-			d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+			d.RecordStatus(clusterName, status.CreationTimedOut, obj.Object[util.StatusField])
 			metrics.DispatchOperationDurationFromStart("create", start)
 			return util.StatusAllOK
 		}
@@ -179,7 +179,7 @@ func (d *managedDispatcherImpl) Create(clusterName string) {
 			return d.recordOperationError(status.RetrievalFailed, clusterName, op, wrappedErr)
 		}
 
-		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+		d.RecordStatus(clusterName, status.CreationTimedOut, obj.Object[util.StatusField])
 
 		if d.skipAdoptingResources && !d.fedResource.IsNamespaceInHostCluster(obj) {
 			_ = d.recordOperationError(status.AlreadyExists, clusterName, op, errors.Errorf("Resource pre-exist in cluster"))
@@ -226,7 +226,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		}
 		if !util.ObjectNeedsUpdate(obj, clusterObj, version) {
 			// Resource is current
-			d.RecordStatus(clusterName, status.ClusterPropagationOK, clusterObj.Object[util.StatusField])
+			d.RecordStatus(clusterName, status.UpdateTimedOut, clusterObj.Object[util.StatusField])
 			return util.StatusAllOK
 		}
 
@@ -237,7 +237,7 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 		if err != nil {
 			return d.recordOperationError(status.UpdateFailed, clusterName, op, err)
 		}
-		d.RecordStatus(clusterName, status.ClusterPropagationOK, obj.Object[util.StatusField])
+		d.RecordStatus(clusterName, status.UpdateTimedOut, obj.Object[util.StatusField])
 		d.setResourcesUpdated()
 		version = util.ObjectVersion(obj)
 		d.recordVersion(clusterName, version)

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -39,8 +39,21 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				"ready": false,
 				"stage": "absent",
 			},
+			resourcesUpdated: false,
+			expectedChanged:  true,
 		},
 		"No change in clusters with update indicates changed": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"ready": false,
+				"stage": "absent",
+			},
+			resourcesUpdated: true,
+			expectedChanged:  true,
+		},
+		"Change in clusters indicates changed": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
@@ -48,10 +61,6 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				"ready": true,
 				"stage": "deployed",
 			},
-			resourcesUpdated: true,
-			expectedChanged:  true,
-		},
-		"Change in clusters indicates changed": {
 			expectedChanged: true,
 		},
 		"Transition indicates changed": {
@@ -65,7 +74,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			propStatus := &GenericFederatedStatus{
+			fedStatus := &GenericFederatedStatus{
 				Clusters: []GenericClusterStatus{
 					{
 						Name: "cluster1",
@@ -86,7 +95,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				StatusMap:        tc.resourceStatusMap,
 				ResourcesUpdated: tc.resourcesUpdated,
 			}
-			changed := propStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus)
+			changed := fedStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus, true)
 			if tc.expectedChanged != changed {
 				t.Fatalf("Expected changed to be %v, got %v", tc.expectedChanged, changed)
 			}

--- a/test/common/bindata.go
+++ b/test/common/bindata.go
@@ -397,7 +397,7 @@ spec:
   - name: PushReconciler
     configuration: "Enabled"
   - name: RawResourceStatusCollection
-    configuration: "Disabled"
+    configuration: "Enabled"
   - name: SchedulerPreferences
     configuration: "Enabled"
   - name: CrossClusterServiceDiscovery

--- a/test/common/typeconfig.go
+++ b/test/common/typeconfig.go
@@ -33,3 +33,12 @@ func GetTypeConfig(genericClient client.Client, name, namespace string) (typecon
 
 	return typeConfig, nil
 }
+
+func UpdateTypeConfig(genericClient client.Client, typeConfig *fedv1b1.FederatedTypeConfig, namespace string) error {
+	err := genericClient.Update(context.Background(), typeConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	kubeclientset "k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/kubefed/pkg/apis/core/typeconfig"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	genericclient "sigs.k8s.io/kubefed/pkg/client/generic"
 	"sigs.k8s.io/kubefed/pkg/controller/sync/status"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
@@ -38,6 +40,8 @@ import (
 
 	. "github.com/onsi/ginkgo" //nolint:stylecheck
 )
+
+var containedTypeNames = []string{"jobs.batch", "deployments.apps", "replicasets.apps"}
 
 type testObjectsAccessor func(namespace string, clusterNames []string) (targetObject *unstructured.Unstructured, overrides []interface{}, err error)
 
@@ -61,6 +65,24 @@ var _ = Describe("Federated", func() {
 				crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
 				crudTester.CheckLifecycle(targetObject, overrides)
 			})
+
+			for _, remoteStatusTypeName := range containedTypeNames {
+				if typeConfigName == remoteStatusTypeName && (os.Getenv("E2E_TEST_REMOTE_STATUS") != "") {
+					It("should be created, read its remote status and deleted successfully", func() {
+						typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)
+						crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+						fedObject := crudTester.CheckCreate(targetObject, overrides)
+
+						By("Checking the remote status filled for each federated resource for every cluster")
+						tl.Logf("Checking the existence of a remote status for each fedObj in every cluster: %v", fedObject)
+						crudTester.CheckRemoteStatus(fedObject, targetObject)
+
+						defer func() {
+							crudTester.CheckDelete(fedObject, false)
+						}()
+					})
+				}
+			}
 
 			// The tests that follow only need to be executed against
 			// a single namespaced type.
@@ -248,6 +270,19 @@ func getCrudTestInput(f framework.KubeFedFramework, tl common.TestLogger,
 		tl.Fatalf("Error retrieving federatedtypeconfig %q: %v", typeConfigName, err)
 	}
 
+	if os.Getenv("E2E_TEST_REMOTE_STATUS") != "" {
+		// Enable the Status Collection for this type of resource
+		tl.Logf("Enabling remote status collection for %v", typeConfig.GetFederatedType().Kind)
+		tc := typeConfig.(*v1beta1.FederatedTypeConfig)
+		statusCollection := v1beta1.StatusCollectionEnabled
+		tc.Spec.StatusCollection = &statusCollection
+
+		err = common.UpdateTypeConfig(client, tc, f.KubeFedSystemNamespace())
+		if err != nil {
+			tl.Fatalf("Error updating the federatedtypeconfig %q: %v", typeConfigName, err)
+		}
+	}
+
 	if framework.TestContext.LimitedScope && !typeConfig.GetNamespaced() {
 		framework.Skipf("Federation of cluster-scoped type %s is not supported by a namespaced control plane.", typeConfigName)
 	}
@@ -262,6 +297,7 @@ func getCrudTestInput(f framework.KubeFedFramework, tl common.TestLogger,
 			targetObject.SetName(namespace)
 			targetObject.SetNamespace(namespace)
 		}
+
 		overrides, err := common.OverridesFromFixture(clusterNames, fixture)
 		if err != nil {
 			return nil, nil, err
@@ -297,6 +333,7 @@ func initCrudTestWithPropagation(f framework.KubeFedFramework, tl common.TestLog
 
 	kubeConfig := f.KubeConfig()
 	targetAPIResource := typeConfig.GetTargetType()
+
 	testClusters := f.ClusterDynamicClients(&targetAPIResource, userAgent)
 	crudTester, err := common.NewFederatedTypeCrudTester(tl, typeConfig, kubeConfig, testClusters, framework.PollInterval, framework.TestContext.SingleCallTimeout)
 	if err != nil {

--- a/test/e2e/defaulting.go
+++ b/test/e2e/defaulting.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -97,6 +98,13 @@ var _ = Describe("Default", func() {
 					},
 					Scope: apiextv1b1.ClusterScoped, // Required
 				},
+			}
+			if os.Getenv("E2E_TEST_REMOTE_STATUS") != "" {
+				tl.Logf("Enabling %v feature!", features.RawResourceStatusCollection)
+				defaultKubeFedConfig.Spec.FeatureGates = append(defaultKubeFedConfig.Spec.FeatureGates, v1beta1.FeatureGatesConfig{
+					Name:          string(features.RawResourceStatusCollection),
+					Configuration: v1beta1.ConfigurationEnabled,
+				})
 			}
 		}
 

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -71,7 +72,8 @@ func SetUpControlPlane() {
 		KubeFedNamespaces: util.KubeFedNamespaces{
 			KubeFedNamespace: TestContext.KubeFedSystemNamespace,
 		},
-		KubeConfig: config,
+		KubeConfig:                  config,
+		RawResourceStatusCollection: (os.Getenv("E2E_TEST_REMOTE_STATUS") != ""),
 	})
 }
 
@@ -168,7 +170,7 @@ func (f *UnmanagedFramework) AfterEach() {
 }
 
 func (f *UnmanagedFramework) ControllerConfig() *util.ControllerConfig {
-	return &util.ControllerConfig{
+	controllerCfg := &util.ControllerConfig{
 		KubeFedNamespaces: util.KubeFedNamespaces{
 			KubeFedNamespace: TestContext.KubeFedSystemNamespace,
 			TargetNamespace:  f.inMemoryTargetNamespace(),
@@ -176,6 +178,8 @@ func (f *UnmanagedFramework) ControllerConfig() *util.ControllerConfig {
 		KubeConfig:      f.Config,
 		MinimizeLatency: true,
 	}
+	controllerCfg.RawResourceStatusCollection = true
+	return controllerCfg
 }
 
 func (f *UnmanagedFramework) Logger() common.TestLogger {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I added some changes to the original KEP.
I polished some code in the controllers.

TODO: add e2e tests for thee resource status collection.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
