### PR TITLE
Release v0.10.3 helm chart

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,20 @@ apiVersion: v1
 entries:
   kubefed:
   - apiVersion: v2
+    created: "2023-06-12T11:43:24.195405532-07:00"
+    dependencies:
+    - condition: controllermanager.enabled
+      name: controllermanager
+      repository: https://localhost/
+      version: 0.10.3
+    description: KubeFed helm chart
+    digest: 45595c11cc76d94f4130ac6cbff36a2fc032fc752856b95f3687e2e81d854748
+    kubeVersion: '>= 1.16.0-0'
+    name: kubefed
+    urls:
+    - https://github.com/mesosphere/kubefed/releases/download/v0.10.3/kubefed-0.10.3.tgz
+    version: 0.10.3
+  - apiVersion: v2
     created: "2023-04-10T16:19:29.588026607-07:00"
     dependencies:
     - condition: controllermanager.enabled
@@ -281,4 +295,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc1/kubefed-0.1.0-rc1.tgz
     version: 0.1.0-rc1
-generated: "2023-04-10T16:19:29.585681613-07:00"
+generated: "2023-06-12T11:43:24.194016916-07:00"

--- a/docs/releasing-fork.md
+++ b/docs/releasing-fork.md
@@ -1,0 +1,20 @@
+## Releasing kubefed from `mesosphere/kubefed`
+
+This repo is primarily used for:
+
+1. Publishing docker images on `ghcr.io` for consumption by DKP
+2. Publishing helm charts on `master` branch for consumption by DKP
+3. Consumption of kubefed as go module dependency in some DKP components.
+
+
+In order to publish docker images, [test-and-push](../.github/workflows/test-and-push.yml) workflow is leveraged. This gets triggered upon pushing a tag. Helm charts can then be pushed by running `./scripts/build-release-artifacts.sh <RELEASE_TAG>` which should update the [charts/index.yaml](../charts/index.yaml). These changes should be merged after the above workflow has completed which might take a while.
+
+Here is the gist of the manual release process:
+
+1. Push a tag from `master`.
+2. Wait for `test-and-push` workflow to complete.
+3. Run `./scripts/build-release-artifacts.sh <RELEASE_TAG>` locally.
+4. Create a PR by adding changes for [charts/index.yaml](../charts/index.yaml). Sample PR https://github.com/mesosphere/kubefed/pull/15
+5. Merge the PR and the helm chart, docker image, go modules should be ready for consumption :rocket:.
+
+Right now, we only needed to release patch versions so far. Release branches are not a thing yet as we hope to archive this repo in near future and no major/minor changes are planned.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,3 +1,5 @@
+See [releasing-fork](./releasing-fork.md) to see the most recent release guide.
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This is the output of running 

```bash
./scripts/build-release-artifacts.sh v0.10.3
```

This PR should be merged AFTER v0.10.3 release is published (as it relies on the valid urls for the helm chart tarball)

Image is being published by https://github.com/mesosphere/kubefed/actions/runs/5247298275

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
