### PR TITLE
feat: Envtest version upgraded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ all: container hyperfed controller kubefedctl webhook e2e
 # Unit tests
 test:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	source <(setup-envtest use -p env 1.28.x) && \
+	source <(setup-envtest use -p env 1.31.x) && \
 		go test $(TEST_PKGS)
 
 build: hyperfed controller kubefedctl webhook

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -50,7 +50,7 @@ curl "${curl_args}" "${kb_url}" \
   | tar xzP -C "${dest_dir}" --strip-components=2
 
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-source <(setup-envtest use -p env 1.28.x)
+source <(setup-envtest use -p env 1.31.x)
 
 echo "KUBEBUILDER_ASSETS is set to ${KUBEBUILDER_ASSETS}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the Envtest version to 1.31.x

JIRA : https://jira.nutanix.com/browse/NCN-105222
