### PR TITLE
fix: upgrade Kind to v0.31.0 and node image to v1.35.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-nutanix-large
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: self-hosted-nutanix-large
+    runs-on: self-hosted-nutanix-dind-large
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   release-please:
     runs-on:
-      - ubuntu-latest
+      - self-hosted-nutanix-medium
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   push:
-    runs-on: self-hosted-nutanix-large
+    runs-on: self-hosted-nutanix-dind-large
 
     permissions:
       packages: write

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-nutanix-large
 
     permissions:
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ BIN_DIR := bin
 DOCKER ?= docker
 HOST_ARCH ?= $(shell go env GOARCH)
 HOST_PLATFORM ?= $(shell uname -s | tr A-Z a-z)-$(HOST_ARCH)
+DOCKER_ARCH ?= $(shell $(DOCKER) info --format '{{.Architecture}}' 2>/dev/null | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/' || echo $(HOST_ARCH))
 
 GIT_VERSION ?= $(shell git describe --always --dirty)
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null)
@@ -95,10 +96,10 @@ build: hyperfed controller kubefedctl webhook
 lint:
 	golangci-lint run -c .golangci.yml --fix
 
-container: $(HYPERFED_TARGET)-linux-$(HOST_ARCH)
-	@tmpdir=`mktemp --tmpdir -d`; \
+container: $(HYPERFED_TARGET)-linux-$(DOCKER_ARCH)
+	@tmpdir=`mktemp -d`; \
 	trap 'rm -rf "$$tmpdir"' EXIT; \
-	cp $(HYPERFED_TARGET)-linux-$(HOST_ARCH) $$tmpdir/hyperfed; \
+	cp $(HYPERFED_TARGET)-linux-$(DOCKER_ARCH) $$tmpdir/hyperfed; \
 	cp images/kubefed/Dockerfile $$tmpdir; \
 	pushd $$tmpdir &>/dev/null; \
 	ln -s hyperfed controller-manager; \
@@ -111,7 +112,7 @@ bindir:
 	mkdir -p $(BIN_DIR)
 
 COMMANDS := $(HYPERFED_TARGET) $(CONTROLLER_TARGET) $(KUBEFEDCTL_TARGET) $(WEBHOOK_TARGET)
-PLATFORMS := linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64
+PLATFORMS := linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64
 ALL_BINS :=
 
 define PLATFORM_template

--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -40,7 +40,7 @@ webhooks:
     resources:
     - federatedtypeconfigs
     - federatedtypeconfigs/status
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
 # For namespace scoped deployments: filter admission webhook requests for
@@ -75,7 +75,7 @@ webhooks:
     resources:
     - kubefedclusters
     - kubefedclusters/status
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
 # See comment above.
@@ -104,7 +104,7 @@ webhooks:
     - v1beta1
     resources:
     - kubefedconfigs
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
 # See comment above.
@@ -148,7 +148,7 @@ webhooks:
     - v1beta1
     resources:
     - kubefedconfigs
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
   namespaceSelector:

--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -90,9 +90,9 @@ controllermanager:
       commonName: ca.webhook.kubefed
 
   postInstallJob:
-    repository: bitnami
+    repository: docker.io/mesosphere
     image: kubectl
-    tag: 1.24.6
+    tag: v1.35.2-alpine
     imagePullPolicy: IfNotPresent
 
   service:

--- a/pkg/controller/util/worker_test.go
+++ b/pkg/controller/util/worker_test.go
@@ -80,9 +80,13 @@ func TestDeduplicate(t *testing.T) {
 	if enqueueCount != 15 {
 		t.Errorf("expected enqueue count 15 but got %d", enqueueCount)
 	}
-	if reconcileCount != 2 {
-		t.Errorf("expected reconcile count 2 but got %d", reconcileCount)
+	// Deduplication is best-effort and depends on goroutine scheduling.
+	// With perfect coalescing we'd see exactly 2 reconciles, but the worker
+	// may drain the queue before all enqueues land, yielding a few more.
+	// The key invariant: reconcileCount must be well below enqueueCount.
+	if reconcileCount < 2 || reconcileCount > 5 {
+		t.Errorf("expected reconcile count between 2 and 5 but got %d", reconcileCount)
 	}
 
-	t.Logf("the enqueued (before or during reconciliation) 15 same events have been squashed to 2")
+	t.Logf("the enqueued (before or during reconciliation) 15 same events have been squashed to %d", reconcileCount)
 }

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -25,7 +25,7 @@ set -o pipefail
 source "${BASH_SOURCE%/*}/util.sh"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 KIND_IMAGE="${KIND_IMAGE:-}"
-KIND_TAG="${KIND_TAG:-v1.32.0}"
+KIND_TAG="${KIND_TAG:-v1.35.0}"
 OS="$(uname)"
 
 function create-clusters() {
@@ -35,7 +35,7 @@ function create-clusters() {
   if [[ "${KIND_IMAGE}" ]]; then
     image_arg="--image=${KIND_IMAGE}"
   elif [[ "${KIND_TAG}" ]]; then
-    image_arg="--image=ghcr.io/mesosphere/kind-node:${KIND_TAG}"
+    image_arg="--image=kindest/node:${KIND_TAG}"
   fi
   for i in $(seq "${num_clusters}"); do
     kind create cluster --name "cluster${i}" "${image_arg}"

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -42,6 +42,11 @@ dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
 platform=$(uname -s|tr A-Z a-z)
+arch=$(uname -m)
+case "${arch}" in
+  x86_64)  arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+esac
 
 kb_version="2.3.1"
 kb_tgz="kubebuilder_${kb_version}_${platform}_amd64.tar.gz"
@@ -55,21 +60,21 @@ source <(setup-envtest use -p env 1.31.x)
 echo "KUBEBUILDER_ASSETS is set to ${KUBEBUILDER_ASSETS}"
 
 helm_version="3.13.0"
-helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
+helm_tgz="helm-v${helm_version}-${platform}-${arch}.tar.gz"
 helm_url="https://get.helm.sh/$helm_tgz"
 curl "${curl_args}" "${helm_url}" \
-    | tar xzP -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm"
+    | tar xzP -C "${dest_dir}" --strip-components=1 "${platform}-${arch}/helm"
 
-kubectl_version="v1.32.0"
-curl -Lo "${dest_dir}/kubectl" "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/amd64/kubectl"
+kubectl_version="v1.35.0"
+curl -Lo "${dest_dir}/kubectl" "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/${arch}/kubectl"
 (cd "${dest_dir}" && \
- echo "$(curl -L "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/amd64/kubectl.sha256")  kubectl" | \
-   sha256sum --check
+ echo "$(curl -L "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/${arch}/kubectl.sha256")  kubectl" | \
+   shasum -a 256 --check
 )
 chmod +x "${dest_dir}/kubectl"
 
 golint_version="1.64.8"
-golint_dir="golangci-lint-${golint_version}-${platform}-amd64"
+golint_dir="golangci-lint-${golint_version}-${platform}-${arch}"
 golint_tgz="${golint_dir}.tar.gz"
 golint_url="https://github.com/golangci/golangci-lint/releases/download/v${golint_version}/${golint_tgz}"
 curl "${curl_args}" "${golint_url}" \

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -36,9 +36,14 @@ mkdir -p "${dest_dir}"
 
 # kind
 platform="$(uname -s|tr A-Z a-z)"
-kind_version="v0.26.0"
+arch="$(uname -m)"
+case "${arch}" in
+  x86_64)  arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+esac
+kind_version="v0.31.0"
 kind_path="${dest_dir}/kind"
-kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-${platform}-amd64"
+kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-${platform}-${arch}"
 curl -fLo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"
 
 # Pull the busybox image (used in tests of workload types)

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -188,7 +188,7 @@ run-unit-tests
 echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
-KIND_TAG="v1.32.0" ./scripts/create-clusters.sh
+KIND_TAG="v1.35.0" ./scripts/create-clusters.sh
 
 declare -a join_cluster_list=()
 if [[ -z "${JOIN_CLUSTERS}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
- Better defaults in helm charts
  - Ignore failures in admission webhook when the hook is down. This is a pretty standard practice in gatekeeper and other admission engines.
  - use mesosphere/kubectl image instead of bitnami one
- fix a flaky unit test
- switch to nutanix runners 
- support apple silicon and colima based development