### PR TITLE
chore: add v0.11.0, v0.11.1, v0.11.2 helm charts to repo index

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -16,10 +16,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+
+      - name: Run tests
+        run: DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -2,6 +2,48 @@ apiVersion: v1
 entries:
   kubefed:
   - apiVersion: v2
+    created: "2026-05-15T23:21:44.063399-07:00"
+    dependencies:
+    - condition: controllermanager.enabled
+      name: controllermanager
+      repository: https://localhost/
+      version: 0.11.2
+    description: KubeFed helm chart
+    digest: d3ef6006378f75527ee661e81042cab961efe6d8a27957d92935e98397ab9610
+    kubeVersion: '>= 1.16.0-0'
+    name: kubefed
+    urls:
+    - https://github.com/mesosphere/kubefed/releases/download/v0.11.2/kubefed-0.11.2.tgz
+    version: 0.11.2
+  - apiVersion: v2
+    created: "2026-05-15T23:22:40.572802-07:00"
+    dependencies:
+    - condition: controllermanager.enabled
+      name: controllermanager
+      repository: https://localhost/
+      version: 0.11.1
+    description: KubeFed helm chart
+    digest: 5e434b02947ad579babc1c292897abe4166dc1e7818aa4f9297dbf33088e17e0
+    kubeVersion: '>= 1.16.0-0'
+    name: kubefed
+    urls:
+    - https://github.com/mesosphere/kubefed/releases/download/v0.11.1/kubefed-0.11.1.tgz
+    version: 0.11.1
+  - apiVersion: v2
+    created: "2026-05-15T23:22:40.563018-07:00"
+    dependencies:
+    - condition: controllermanager.enabled
+      name: controllermanager
+      repository: https://localhost/
+      version: 0.11.0
+    description: KubeFed helm chart
+    digest: 91cc8aed0439435548020150db9130657d7f870c547d5ed79179ac7df42adb8b
+    kubeVersion: '>= 1.16.0-0'
+    name: kubefed
+    urls:
+    - https://github.com/mesosphere/kubefed/releases/download/v0.11.0/kubefed-0.11.0.tgz
+    version: 0.11.0
+  - apiVersion: v2
     created: "2023-12-21T17:52:41.724369Z"
     dependencies:
     - condition: controllermanager.enabled
@@ -309,4 +351,4 @@ entries:
     urls:
     - https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc1/kubefed-0.1.0-rc1.tgz
     version: 0.1.0-rc1
-generated: "2023-12-21T17:52:41.722649Z"
+generated: "2026-05-15T23:22:40.557921-07:00"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -72,7 +72,7 @@ function run-e2e-upgrade-test() {
   KUBEFED_UPGRADE_TEST_VERSION="${KUBEFED_UPGRADE_TEST_VERSION#v}"
 
   echo "Installing an older kubefed version v${KUBEFED_UPGRADE_TEST_VERSION}"
-  helm repo add kubefed-charts https://raw.githubusercontent.com/mesosphere/kubefed/tga/enable-e2e/charts
+  helm repo add kubefed-charts https://raw.githubusercontent.com/mesosphere/kubefed/main/charts
   helm repo update
   helm install kubefed kubefed-charts/kubefed --namespace ${KUBEFED_UPGRADE_TEST_NS} --version=${KUBEFED_UPGRADE_TEST_VERSION} --create-namespace --wait
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -67,18 +67,17 @@ function run-e2e-tests() {
 function run-e2e-upgrade-test() {
   HOST_CLUSTER="$(kubectl config current-context)"
 
-  echo "Adding a repo to install an older kubefed version"
-  helm repo add kubefed-charts https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
-  helm repo  update
-
-  # Get the previous version prior to our latest stable version
-  KUBEFED_UPGRADE_TEST_VERSION=$(helm search repo kubefed-charts/kubefed  --versions | awk '{print $2}' | head -3 | tail -1)
+  # Get the latest stable release tag to upgrade from.
+  KUBEFED_UPGRADE_TEST_VERSION=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+  KUBEFED_UPGRADE_TEST_VERSION="${KUBEFED_UPGRADE_TEST_VERSION#v}"
 
   echo "Installing an older kubefed version v${KUBEFED_UPGRADE_TEST_VERSION}"
-  helm install kubefed kubefed-charts/kubefed --namespace ${KUBEFED_UPGRADE_TEST_NS} --version=v${KUBEFED_UPGRADE_TEST_VERSION} --create-namespace --wait
+  helm repo add kubefed-charts https://raw.githubusercontent.com/mesosphere/kubefed/tga/enable-e2e/charts
+  helm repo update
+  helm install kubefed kubefed-charts/kubefed --namespace ${KUBEFED_UPGRADE_TEST_NS} --version=${KUBEFED_UPGRADE_TEST_VERSION} --create-namespace --wait
 
-  deployment-image-as-expected "${KUBEFED_UPGRADE_TEST_NS}" kubefed-admission-webhook admission-webhook "quay.io/kubernetes-multicluster/kubefed:v${KUBEFED_UPGRADE_TEST_VERSION}"
-  deployment-image-as-expected "${KUBEFED_UPGRADE_TEST_NS}" kubefed-controller-manager controller-manager "quay.io/kubernetes-multicluster/kubefed:v${KUBEFED_UPGRADE_TEST_VERSION}"
+  deployment-image-as-expected "${KUBEFED_UPGRADE_TEST_NS}" kubefed-admission-webhook admission-webhook "ghcr.io/mesosphere/kubefed:v${KUBEFED_UPGRADE_TEST_VERSION}"
+  deployment-image-as-expected "${KUBEFED_UPGRADE_TEST_NS}" kubefed-controller-manager controller-manager "ghcr.io/mesosphere/kubefed:v${KUBEFED_UPGRADE_TEST_VERSION}"
 
   echo "Upgrading kubefed to current version"
   IMAGE_NAME="local/kubefed:e2e"


### PR DESCRIPTION
## Summary

Follow up of https://github.com/mesosphere/kubefed/pull/59#issuecomment-4427415669


- Add helm chart entries for v0.11.0, v0.11.1, and v0.11.2 to `charts/index.yaml`
- Chart `.tgz` assets have been uploaded to their respective GitHub releases:
  - [v0.11.0](https://github.com/mesosphere/kubefed/releases/tag/v0.11.0)
  - [v0.11.1](https://github.com/mesosphere/kubefed/releases/tag/v0.11.1)
  - [v0.11.2](https://github.com/mesosphere/kubefed/releases/tag/v0.11.2)

These releases were previously missing chart assets because `build-release-artifacts.sh` was not run after release-please created them.

Reference: https://github.com/mesosphere/kubefed/pull/15