### PR TITLE
fix: apply KubeFedConfig defaults inline before SSA apply

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/kubefed/cmd/controller-manager/app/leaderelection"
 	"sigs.k8s.io/kubefed/cmd/controller-manager/app/options"
 	corev1b1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/defaults"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1/validation"
 	genericclient "sigs.k8s.io/kubefed/pkg/client/generic"
 	"sigs.k8s.io/kubefed/pkg/controller/federatedtypeconfig"
@@ -327,6 +328,7 @@ func setOptionsByKubeFedConfig(opts *options.Options) {
 			},
 		}
 	}
+	defaults.SetDefaultKubeFedConfig(fedConfig)
 	setDefaultKubeFedConfigScope(fedConfig)
 	applyKubeFedConfig(opts.Config.KubeConfig, fedConfig)
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -72,7 +72,7 @@ function run-e2e-upgrade-test() {
   KUBEFED_UPGRADE_TEST_VERSION="${KUBEFED_UPGRADE_TEST_VERSION#v}"
 
   echo "Installing an older kubefed version v${KUBEFED_UPGRADE_TEST_VERSION}"
-  helm repo add kubefed-charts https://raw.githubusercontent.com/mesosphere/kubefed/main/charts
+  helm repo add kubefed-charts https://raw.githubusercontent.com/mesosphere/kubefed/master/charts
   helm repo update
   helm install kubefed kubefed-charts/kubefed --namespace ${KUBEFED_UPGRADE_TEST_NS} --version=${KUBEFED_UPGRADE_TEST_VERSION} --create-namespace --wait
 


### PR DESCRIPTION
## Summary

- The SSA refactoring in b5fdf684 (`fix: use server-side apply for KubeFedConfig to prevent race with Helm (#59)`) replaced `client.Create()` with server-side apply. The old `Create` path relied on the mutating admission webhook (`/default-kubefedconfig`) to populate all default spec values (durations, leader election, health checks, feature gates, etc.). On fresh installs the controller-manager starts before the webhook pod is ready (and we have changed the webhook failurePolicy to `Ignore` to ensure SSA doesn't block the request), so the SSA Patch creates a KubeFedConfig with only `spec.scope: ""` and no other fields — validation then fails and the controller crash-loops.
- Adds an inline call to `defaults.SetDefaultKubeFedConfig()` in `setOptionsByKubeFedConfig` before the SSA apply and validation, so defaults are always populated regardless of webhook availability.

## Root Cause

```yaml
# What the KubeFedConfig looked like — completely empty except scope
spec:
  scope: ""
```

`setOptionsByKubeFedConfig` builds an empty `KubeFedConfig` when none exists, then applies it via SSA without ever populating defaults. The webhook that would normally default the object is not yet running during bootstrap.

## Test plan

- [x] Deploy on a fresh cluster and verify `kubectl get kubefedconfigs -A -oyaml` shows a fully-populated spec with all default fields
- [x] Verify the controller-manager starts cleanly without crash-looping
- [x] Verify that an existing KubeFedConfig with user-customized values is not overwritten (defaults only fill nil fields)
- [x] Verify that `DEFAULT_KUBEFED_SCOPE` env var still overrides the scope after defaulting


Made with [Cursor](https://cursor.com)