### PR TITLE
fix: stop controller-manager from creating KubeFedConfig CR

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -35,11 +35,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	_ "sigs.k8s.io/controller-runtime/pkg/metrics" // for workqueue metrics registration
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -281,46 +279,15 @@ func setDefaultKubeFedConfigScope(fedConfig *corev1b1.KubeFedConfig) bool {
 	return false
 }
 
-func applyKubeFedConfig(config *rest.Config, fedConfig *corev1b1.KubeFedConfig) {
-	qualifiedName := util.QualifiedName{
-		Namespace: fedConfig.Namespace,
-		Name:      fedConfig.Name,
-	}
-
-	// Build a clean desired-state object for SSA; only Name, Namespace,
-	// TypeMeta and Spec matter. Copying from the fetched object would carry
-	// server-set metadata (managedFields, resourceVersion, …) that SSA rejects.
-	applyObj := &corev1b1.KubeFedConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: corev1b1.SchemeGroupVersion.String(),
-			Kind:       "KubeFedConfig",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        fedConfig.Name,
-			Namespace:   fedConfig.Namespace,
-			Labels:      fedConfig.Labels,
-			Annotations: fedConfig.Annotations,
-		},
-		Spec: fedConfig.Spec,
-	}
-
-	client := genericclient.NewForConfigOrDieWithUserAgent(config, "kubefedconfig")
-	err := client.Patch(context.Background(), applyObj, runtimeclient.Apply,
-		runtimeclient.FieldOwner("kubefed-controller-manager"))
-	if apierrors.IsConflict(err) {
-		klog.Infof("KubeFedConfig %q has field ownership conflicts with another manager, skipping apply: %v", qualifiedName, err)
-		return
-	}
-	if err != nil {
-		klog.Fatalf("Error applying KubeFedConfig %q: %v", qualifiedName, err)
-	}
-}
-
 func setOptionsByKubeFedConfig(opts *options.Options) {
 	fedConfig := getKubeFedConfig(opts)
 	if fedConfig == nil {
-		// If the KubeFedConfig is not found, create a new one with the default values.
-		// If the KubeFedConfig is found, then either an old controller manager created it or it was created by the helm chart itself in which case we can use it as is.
+		// KubeFedConfig not found on the cluster yet. The Helm chart is the
+		// sole owner of this CR -- do NOT create it here. Writing it from the
+		// controller-manager races with Helm SSA and triggers a Helm v4 bug
+		// ("original object KubeFedConfig not found") that fails the install.
+		// Use in-memory defaults instead; the chart-managed CR will be picked
+		// up on the next restart once the install succeeds.
 		fedConfig = &corev1b1.KubeFedConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      util.KubeFedConfigName,
@@ -330,7 +297,6 @@ func setOptionsByKubeFedConfig(opts *options.Options) {
 		defaults.SetDefaultKubeFedConfig(fedConfig)
 		setDefaultKubeFedConfigScope(fedConfig)
 	}
-	applyKubeFedConfig(opts.Config.KubeConfig, fedConfig)
 
 	qualifedName := util.QualifiedName{
 		Name:      fedConfig.Name,


### PR DESCRIPTION
## Summary

- Remove `applyKubeFedConfig()` — the controller-manager no longer creates/applies the `KubeFedConfig` CR via SSA on startup
- The Helm chart is now the sole owner of the `KubeFedConfig` CR
- If the CR doesn't exist yet (during initial startup), in-memory defaults are used

## Problem

The `kubefed` HelmRelease fails on first install in ~12 seconds with:

```
original object KubeFedConfig with the name "kubefed" not found
```

This triggers an install/uninstall crash loop (observed: 10+ `installFailures` with 30 retries configured).

### Root Cause

The `KubeFedConfig` CR is created by **two writers** that race during the first install:

1. **Helm chart** (`charts/kubefed/charts/controllermanager/templates/kubefedconfig.yaml`) — applied by Flux SSA
2. **Controller-manager** (`setOptionsByKubeFedConfig()` → `applyKubeFedConfig()`) — runs on pod startup, **before leader election**

Helm v4 SSA applies resources in kind-order: Deployments are applied before CustomResources. So the controller-manager pod starts and creates the `KubeFedConfig` CR **before** Helm SSA gets to it. When Helm then tries to apply the chart's `KubeFedConfig`:

1. `helper.Get()` → finds the CR (created by controller-manager) ✓
2. `originals.Get()` → returns `nil` (first install, no prior Helm release) ✗
3. Helm v4 bug ([helm/helm#13437](https://github.com/helm/helm/issues/13437)): immediately returns `original object KubeFedConfig with the name "kubefed" not found`

The fix was merged upstream in [helm/helm#31412](https://github.com/helm/helm/pull/31412) and included in Helm v4.2.0 / helm-controller v1.5.5. But the correct fix is to eliminate the race condition at the source — the controller-manager should not create a CR that the Helm chart already manages.

## Test plan

- [ ] Fresh cluster install: `kubefed` HelmRelease installs successfully on the first attempt (no 12-second failures)
- [ ] Upgrade from previous version: controller-manager starts correctly, reads existing `KubeFedConfig` from cluster
- [ ] `KubeFedConfig` not found on startup: controller-manager uses in-memory defaults and starts without error
- [ ] Feature gates and custom config values from Helm chart are picked up after successful install + pod restart